### PR TITLE
Migrate to jax plus small technical improvements

### DIFF
--- a/binning.py
+++ b/binning.py
@@ -5,7 +5,7 @@ from jax import grad, hessian, jacobian, config
 from jax.scipy.special import erf
 config.update('jax_enable_x64', True)
 
-etas = np.arange(-0.8, 1.2, 0.4)
+etas = np.arange(-0.8, 1.2, 0.4, dtype='float64')
 #etas = np.array((-0.8,0.8))
 ptsJ = np.array((4.31800938,5.2385931,6.77045488,930.92053223),dtype='float64') #quantiles
 ptsJC = np.array((0.1703978,0.21041214,0.26139158),dtype='float64') #bin centers in curvature

--- a/binning.py
+++ b/binning.py
@@ -1,4 +1,9 @@
-import numpy as np
+#import numpy as np
+import jax
+import jax.numpy as np
+from jax import grad, hessian, jacobian, config
+from jax.scipy.special import erf
+config.update('jax_enable_x64', True)
 
 etas = np.arange(-0.8, 1.2, 0.4)
 #etas = np.array((-0.8,0.8))

--- a/calInput.py
+++ b/calInput.py
@@ -13,13 +13,14 @@ parser.add_argument('-isJ', '--isJ', default=False, action='store_true', help='U
 parser.add_argument('-smearedMC', '--smearedMC', default=False, action='store_true', help='Use smeared gen mass in MC, omit for using reco mass')
 parser.add_argument('-isData', '--isData', default=False, action='store_true', help='Use if data, omit if MC')
 parser.add_argument('-runClosure', '--runClosure', default=False, action='store_true', help='Use to apply full calibration. If omit, rescale data for B map and leave MC as it is')
+parser.add_argument('-dataDir', '--dataDir', default='/scratchssd/emanca/wproperties-analysis/muonCalibration/', type=str, help='set the directory for input data')
 
 args = parser.parse_args()
 isJ = args.isJ
 smearedMC = args.smearedMC
 isData = args.isData
 runClosure = args.runClosure
-
+dataDir = args.dataDir
 
 ROOT.ROOT.EnableImplicitMT()
 RDF = ROOT.ROOT.RDataFrame
@@ -43,11 +44,11 @@ if not isData:
     cut+= '&& mcpt1>0. && mcpt2>0.'
 
 if isJ:
-    inputFileMC ='/scratchssd/emanca/wproperties-analysis/muonCalibration/muonTree.root'
-    inputFileD ='/scratchssd/emanca/wproperties-analysis/muonCalibration/muonTreeData.root'
+    inputFileMC ='%s/muonTree.root' % dataDir
+    inputFileD ='%s/muonTreeData.root' % dataDir
 else:
-    inputFileMC ='/scratchssd/emanca/wproperties-analysis/muonCalibration/muonTreeMCZ.root'
-    inputFileD ='/scratchssd/emanca/wproperties-analysis/muonCalibration/muonTreeDataZ.root'
+    inputFileMC ='%s/muonTreeMCZ.root' % dataDir
+    inputFileD ='%s/muonTreeDataZ.root' % dataDir
 
 if isData: inputFile = inputFileD
 else: inputFile = inputFileMC
@@ -71,12 +72,12 @@ d = d.Filter(cut)\
      .Define('v2sm', 'ROOT::Math::PtEtaPhiMVector(mcpt2+myRndGens[rdfslot_].Gaus(0., cErr2*pt2),eta2,phi2,0.105)')\
      .Define('smearedgenMass', '(v1sm+v2sm).M()')
 
-f = ROOT.TFile.Open('/scratchssd/emanca/wproperties-analysis/muonCalibration/calibData/bFieldMap.root')
+f = ROOT.TFile.Open('%s/bFieldMap.root' % dataDir)
 bFieldMap = f.Get('bfieldMap')
 
-if runClosure: print 'taking corrections from', '/scratchssd/emanca/wproperties-analysis/muonCalibration/calibData/scale_{}_80X_13TeV.root'.format('DATA' if isData else 'MC')
+if runClosure: print 'taking corrections from', '{}/scale_{}_80X_13TeV.root'.format(dataDir, 'DATA' if isData else 'MC')
 
-f2 = ROOT.TFile.Open('/scratchssd/emanca/wproperties-analysis/muonCalibration/calibData/scale_{}_80X_13TeV.root'.format('DATA' if isData else 'MC'))
+f2 = ROOT.TFile.Open('{}/scale_{}_80X_13TeV.root'.format(dataDir, 'DATA' if isData else 'MC'))
 A = f2.Get('magnetic')
 e = f2.Get('e')
 M = f2.Get('B')

--- a/fittingFunctionsBinned.py
+++ b/fittingFunctionsBinned.py
@@ -1,5 +1,8 @@
-from autograd import grad, hessian, jacobian
-import autograd.numpy as np
+import jax.numpy as np
+from jax import grad, hessian, jacobian, config
+from jax.scipy.special import erf
+config.update('jax_enable_x64', True)
+
 import ROOT
 import pickle
 from termcolor import colored
@@ -7,7 +10,6 @@ from scipy.optimize import minimize, SR1, LinearConstraint, check_grad, approx_f
 from scipy.optimize import Bounds
 import itertools
 from root_numpy import array2hist, fill_hist
-from autograd.scipy.special import erf
 
 import matplotlib
 matplotlib.use('agg')
@@ -19,7 +21,7 @@ def defineState(nEtaBins,nPtBins,dataset):
     sigma = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),-3.9) 
     nsig = np.log(np.where(np.sum(dataset,axis=2)>0.,np.sum(dataset,axis=2),2.))
         
-    x = np.concatenate((scale.flatten(), sigma.flatten(), nsig.flatten()),axis=None)
+    x = np.concatenate((scale.flatten(), sigma.flatten(), nsig.flatten()),axis=0)
         
     print x.shape, 'x.shape'
                 
@@ -33,7 +35,7 @@ def defineStatebkg(nEtaBins,nPtBins,dataset):
     slope = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),-0.1) 
     nbkg = np.log(np.where(np.sum(dataset,axis=2)>0.,0.1*np.sum(dataset,axis=2),2.))
     
-    x = np.concatenate((scale.flatten(), sigma.flatten(), nsig.flatten(),slope.flatten(),nbkg.flatten()),axis=None)
+    x = np.concatenate((scale.flatten(), sigma.flatten(), nsig.flatten(),slope.flatten(),nbkg.flatten()),axis=0)
     
     print x.shape, 'x.shape'
                 
@@ -48,9 +50,9 @@ def defineStatePars(nEtaBins,nPtBins,dataset, isJ):
     nsig = np.log(np.where(np.sum(dataset,axis=2)>0,np.sum(dataset,axis=2),2))
 
     if isJ:
-        x = np.concatenate((A.flatten(), e.flatten(), M.flatten(), sigma.flatten(), nsig.flatten()),axis=None)
+        x = np.concatenate((A.flatten(), e.flatten(), M.flatten(), sigma.flatten(), nsig.flatten()),axis=0)
     else:
-        x = np.concatenate((A.flatten(), M.flatten(), sigma.flatten(), nsig.flatten()),axis=None)
+        x = np.concatenate((A.flatten(), M.flatten(), sigma.flatten(), nsig.flatten()),axis=0)
 
     print x.shape, 'x.shape'
                 

--- a/fittingFunctionsBinned.py
+++ b/fittingFunctionsBinned.py
@@ -131,7 +131,7 @@ def kernelpdfPars(A, e, M, sigma, dataset, datasetGen, isJ):
     else:
         pts= np.array((20.,30,40,50,60,70,100),dtype='float64')
     
-    etas = np.arange(-0.8, 1.2, 0.4)
+    etas = np.arange(-0.8, 1.2, 0.4, dtype='float64')
     etasC = (etas[:-1] + etas[1:]) / 2.
 
     s = np.sin(2*np.arctan(np.exp(-etasC)))

--- a/runFits.py
+++ b/runFits.py
@@ -3,21 +3,18 @@ import multiprocessing
 
 ncpu = multiprocessing.cpu_count()
 
-os.environ["OMP_NUM_THREADS"] = str(ncpu) # export OMP_NUM_THREADS=4
-os.environ["OPENBLAS_NUM_THREADS"] = str(ncpu) # export OPENBLAS_NUM_THREADS=4 
-os.environ["MKL_NUM_THREADS"] = str(ncpu) # export MKL_NUM_THREADS=6
-os.environ["VECLIB_MAXIMUM_THREADS"] = str(ncpu) # export VECLIB_MAXIMUM_THREADS=4
-os.environ["NUMEXPR_NUM_THREADS"] = str(ncpu) # export NUMEXPR_NUM_THREADS=6
+os.environ["OMP_NUM_THREADS"] = str(ncpu)
+os.environ["OPENBLAS_NUM_THREADS"] = str(ncpu)
+os.environ["MKL_NUM_THREADS"] = str(ncpu)
+os.environ["VECLIB_MAXIMUM_THREADS"] = str(ncpu)
+os.environ["NUMEXPR_NUM_THREADS"] = str(ncpu)
 
-#prepare possible migration to jax
-#import jax.numpy as np
-#from jax import grad, hessian, jacobian, config
-#from jax.scipy.special import erf
-#config.update('jax_enable_x64', True)
-
-from autograd import grad, hessian, jacobian
-import autograd.numpy as np
-from autograd.scipy.special import erf
+import jax
+import jax.numpy as np
+import numpy as onp
+from jax import grad, hessian, jacobian, config
+from jax.scipy.special import erf
+config.update('jax_enable_x64', True)
 
 import ROOT
 import pickle
@@ -34,13 +31,50 @@ import matplotlib.pyplot as plt
 from fittingFunctionsBinned import defineStatePars, nllPars
 from binning import etas, ptsJ, ptsJC, ptsZ
 import argparse
+import functools
 
+#slower but lower memory usage calculation of hessian which
+#explicitly loops over hessian rows
+def hessianlowmem(fun):
+    def _hessianlowmem(x, f):
+        _, hvp = jax.linearize(jax.grad(f), x)
+        hvp = jax.jit(hvp)  # seems like a substantial speedup to do this
+        basis = np.eye(np.prod(x.shape)).reshape(-1, *x.shape)
+        return np.stack([hvp(e) for e in basis]).reshape(x.shape + x.shape)
+    return functools.partial(_hessianlowmem, f=fun)
 
-def scaleFromPars(x):
+    
+#compromise version which vectorizes the calculation, but only partly to save memory
+def hessianoptsplit(fun, vsize=4):
+    def _hessianopt(x, f):
+        _, hvp = jax.linearize(jax.grad(f), x)
+        hvp = jax.jit(hvp)
+        n = np.prod(x.shape)
+        idxs =  np.arange(vsize, n, vsize)
+        basis = np.eye(np.prod(x.shape)).reshape(-1, *x.shape)
+        splitbasis = np.split(basis,idxs)
+        vhvp = jax.vmap(hvp)
+        vhvp = jax.jit(vhvp)
+        return np.concatenate([vhvp(b) for b in splitbasis]).reshape(x.shape + x.shape)
+    return functools.partial(_hessianopt, f=fun)
 
-    A = x[:nEtaBins, np.newaxis]
-    e = x[nEtaBins:2*nEtaBins]
-    M = x[2*nEtaBins:3*nEtaBins]
+#optimized version which is faster than the built-in hessian for some reason
+# **TODO** follow up with jax authors to understand why
+def hessianopt(fun):
+    def _hessianopt(x, f):
+        _, hvp = jax.linearize(jax.grad(f), x)
+        hvp = jax.jit(hvp)
+        vhvp = jax.vmap(hvp)
+        vhvp = jax.jit(vhvp)
+        basis = np.eye(np.prod(x.shape)).reshape(-1, *x.shape)
+        return vhvp(basis).reshape(x.shape + x.shape)
+    return functools.partial(_hessianopt, f=fun)
+
+def scaleFromPars(AeM):
+
+    A = AeM[:nEtaBins, np.newaxis]
+    e = AeM[nEtaBins:2*nEtaBins]
+    M = AeM[2*nEtaBins:3*nEtaBins]
 
     etasC = (etas[:-1] + etas[1:]) / 2.
 
@@ -97,17 +131,17 @@ good_idx = np.where((np.sum(datasetJgen,axis=2)>1000.).flatten())[0]
 
 if runCalibration:
 
-    bad_idx = np.concatenate((idx, idx+sep), axis=None)
-    lb_scale = np.concatenate((0.009*np.ones(nEtaBins),-0.01*np.ones(nEtaBins), -1e-5*np.ones(nEtaBins)),axis=None)
-    ub_scale = np.concatenate((1.001*np.ones(nEtaBins),0.01*np.ones(nEtaBins), 1e-5*np.ones(nEtaBins)),axis=None)
+    bad_idx = np.concatenate((idx, idx+sep), axis=0)
+    lb_scale = np.concatenate((0.009*np.ones(nEtaBins),-0.01*np.ones(nEtaBins), -1e-5*np.ones(nEtaBins)),axis=0)
+    ub_scale = np.concatenate((1.001*np.ones(nEtaBins),0.01*np.ones(nEtaBins), 1e-5*np.ones(nEtaBins)),axis=0)
     pars_idx = np.linspace(0, nEtaBins-1,nEtaBins,dtype=np.int16)
-    good_idx = np.concatenate((pars_idx,nEtaBins+pars_idx,2*nEtaBins+pars_idx,3*nEtaBins+good_idx, 3*nEtaBins+good_idx+sep), axis=None)
+    good_idx = np.concatenate((pars_idx,nEtaBins+pars_idx,2*nEtaBins+pars_idx,3*nEtaBins+good_idx, 3*nEtaBins+good_idx+sep), axis=0)
 
 else:   
-    bad_idx = np.concatenate((idx, idx+sep,idx+2*sep), axis=None)
+    bad_idx = np.concatenate((idx, idx+sep,idx+2*sep), axis=0)
     lb_scale = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),0.).flatten()
     ub_scale = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),2.).flatten()
-    good_idx = np.concatenate((good_idx, good_idx+sep,good_idx+2*sep), axis=None)
+    good_idx = np.concatenate((good_idx, good_idx+sep,good_idx+2*sep), axis=0)
 
 lb_sigma = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),-np.inf).flatten()
 lb_nsig = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),-np.inf).flatten()
@@ -115,45 +149,45 @@ lb_nsig = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),-np.inf).flatten()
 ub_sigma = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),np.inf).flatten()
 ub_nsig = np.full((nEtaBins,nEtaBins,nPtBins,nPtBins),np.inf).flatten()
 
-lb = np.concatenate((lb_scale,lb_sigma,lb_nsig),axis=None)
-ub = np.concatenate((ub_scale,ub_sigma,ub_nsig),axis=None)
+lb = np.concatenate((lb_scale,lb_sigma,lb_nsig),axis=0)
+ub = np.concatenate((ub_scale,ub_sigma,ub_nsig),axis=0)
 
 #bounds for fixed parameters must be equal to the starting values
 if runCalibration:
-    lb[3*nEtaBins+bad_idx] = x[3*nEtaBins+bad_idx]
-    ub[3*nEtaBins+bad_idx] = x[3*nEtaBins+bad_idx]
+    jax.ops.index_update(lb, 3*nEtaBins+bad_idx, x[3*nEtaBins+bad_idx])
+    jax.ops.index_update(ub, 3*nEtaBins+bad_idx, x[3*nEtaBins+bad_idx])
 else:
-    lb[bad_idx] = x[bad_idx]
-    ub[bad_idx] = x[bad_idx]
+    jax.ops.index_update(lb, bad_idx, x[bad_idx])
+    jax.ops.index_update(ub, bad_idx, x[bad_idx])
 
 constraints = LinearConstraint( A=np.eye(x.shape[0]), lb=lb, ub=ub,keep_feasible=True )
 
 if runCalibration:
-    gradnll = grad(nllPars)
-    hessnll = hessian(nllPars)
-
-    res = minimize(nllPars, x, args=(nEtaBins,nPtBins,datasetJ,datasetJgen,isJ),\
-        method = 'trust-constr',jac = gradnll, hess=SR1(),constraints=constraints,\
-        options={'verbose':3,'disp':True,'maxiter' : maxiter, 'gtol' : 0., 'xtol' : xtol, 'barrier_tol' : btol})
+    fnll = nllPars
 else:
-    gradnll = grad(nll)
-    hessnll = hessian(nll)
+    fnll = nll
 
-    res = minimize(nll, x, args=(nEtaBins,nPtBins,datasetJ,datasetJgen,isJ),\
-        method = 'trust-constr',jac = gradnll, hess=SR1(),constraints=constraints,\
-        options={'verbose':3,'disp':True,'maxiter' : maxiter, 'gtol' : 0., 'xtol' : xtol, 'barrier_tol' : btol})
+#convert fnll to single parameter function fnllx(x)
+fnllx = functools.partial(nllPars, nEtaBins=nEtaBins, nPtBins=nPtBins, dataset=datasetJ, datasetGen=datasetJgen, isJ=isJ)
+
+fgradnll = jax.jit(jax.value_and_grad(fnllx))
+hessnll = hessianlowmem(fnllx)
+
+res = minimize(fgradnll, x,\
+    method = 'trust-constr',jac = True, hess=SR1(),constraints=constraints,\
+    options={'verbose':3,'disp':True,'maxiter' : maxiter, 'gtol' : 0., 'xtol' : xtol, 'barrier_tol' : btol})
 
 print res
 
 
 fitres = res.x[good_idx]
 
-gradient = gradnll(res.x,nEtaBins,nPtBins,datasetJ,datasetJgen,isJ)
+val,gradient = fgradnll(res.x)
 gradfinal = gradient[good_idx]
 
 #print gradient, "gradient"
 
-hessian = hessnll(res.x,nEtaBins,nPtBins,datasetJ,datasetJgen,isJ)
+hessian = hessnll(res.x)
 #hessian = np.eye(x.shape[0])
 
 hessmod = hessian[good_idx,:]
@@ -206,16 +240,20 @@ if runCalibration:
 
     scale_idx = np.where((np.sum(datasetJgen,axis=2)>1000.).flatten())[0]
 
-    scale = scaleFromPars(res.x)[scale_idx]
-    jacobianscale = jacobian(scaleFromPars)
-    jac = jacobianscale(res.x)
+    AeM = res.x[:3*nEtaBins]
+    scale = scaleFromPars(AeM)[scale_idx]
+    print("scale:")
+    print(scale)
+    jacobianscale = jax.jit(jax.jacfwd(scaleFromPars))
+    jac = jacobianscale(AeM)
     jac = jac[scale_idx,:]
-    jac = jac[:,good_idx]
-    scale_invhess = np.matmul(np.matmul(jac,invhess),jac.T)
+    invhessAeM = invhess[:3*nEtaBins,:3*nEtaBins]
+    scale_invhess = np.matmul(np.matmul(jac,invhessAeM),jac.T)
     scale_err = np.sqrt(np.diag(scale_invhess))
     print("scale_err:")
     print(scale_err)
-    scaleplot = ROOT.TH1D("scale", "scale", scale_idx.shape[0], np.linspace(0, scale_idx.shape[0], scale_idx.shape[0]+1))
+    #have to use original numpy to construct the bin edges because for some reason this doesn't work with the arrays returned by jax
+    scaleplot = ROOT.TH1D("scale", "scale", scale_idx.shape[0], onp.linspace(0, scale_idx.shape[0], scale_idx.shape[0]+1))
     scaleplot.GetYaxis().SetTitle('scale')
     scaleplot = array2hist(scale, scaleplot, np.sqrt(scale_err))
 

--- a/runFits.py
+++ b/runFits.py
@@ -1,9 +1,13 @@
 import os
-os.environ["OMP_NUM_THREADS"] = "32" # export OMP_NUM_THREADS=4
-os.environ["OPENBLAS_NUM_THREADS"] = "32" # export OPENBLAS_NUM_THREADS=4 
-os.environ["MKL_NUM_THREADS"] = "32" # export MKL_NUM_THREADS=6
-os.environ["VECLIB_MAXIMUM_THREADS"] = "32" # export VECLIB_MAXIMUM_THREADS=4
-os.environ["NUMEXPR_NUM_THREADS"] = "32" # export NUMEXPR_NUM_THREADS=6
+import multiprocessing
+
+ncpu = multiprocessing.cpu_count()
+
+os.environ["OMP_NUM_THREADS"] = str(ncpu) # export OMP_NUM_THREADS=4
+os.environ["OPENBLAS_NUM_THREADS"] = str(ncpu) # export OPENBLAS_NUM_THREADS=4 
+os.environ["MKL_NUM_THREADS"] = str(ncpu) # export MKL_NUM_THREADS=6
+os.environ["VECLIB_MAXIMUM_THREADS"] = str(ncpu) # export VECLIB_MAXIMUM_THREADS=4
+os.environ["NUMEXPR_NUM_THREADS"] = str(ncpu) # export NUMEXPR_NUM_THREADS=6
 
 #prepare possible migration to jax
 #import jax.numpy as np
@@ -82,8 +86,8 @@ print "minimising"
 xtol = np.finfo('float64').eps
 #btol = 1.e-8
 btol = 0.1
-#maxiter = 100000
-maxiter = 2
+maxiter = 100000
+#maxiter = 2
 
 sep = nEtaBins*nEtaBins*nPtBins*nPtBins
 


### PR DESCRIPTION
This includes the migration to jax and a first pass at corresponding optimizations.  (There is still room to speed up the hessian computation in particular, but there is some compute time vs memory tradeoff here.)

Crucially comparing to the existing version with autograd, it looks like there was some truncation of precision to float32 in at least some places, likely within autograd itself.  Now I'm pretty sure everything is float64 all the way through (but as a result the minimization takes more iterations to converge.)

Usage of many cpu cores should be much better, and in principle GPU should be used automatically if present.  (testing this in my own environment will require migrating to python 3)